### PR TITLE
Fix expression in Copilot workflow

### DIFF
--- a/.github/workflows/copilot-pr-review.yml
+++ b/.github/workflows/copilot-pr-review.yml
@@ -120,7 +120,7 @@ jobs:
             }
             
             // Add status label based on Copilot review
-            if ('${{ steps.copilot-review.outcome }}' === 'success') {
+            if (${{ steps.copilot-review.outcome }} === 'success') {
               if (!labels.includes('status: review passed')) labels.push('status: review passed');
             } else {
               if (!labels.includes('status: changes requested')) labels.push('status: changes requested');


### PR DESCRIPTION
This PR fixes an issue in the Copilot workflow where the expression `'${{ steps.copilot-review.outcome }}'` was treated as a literal string rather than a dynamic value.

Changes:
- Changed `if ('${{ steps.copilot-review.outcome }}' === 'success')` to `if (${{ steps.copilot-review.outcome }} === 'success')`

This ensures that the condition correctly reflects the actual outcome of the Copilot review.